### PR TITLE
workflows: add pr-auditor and test plans to PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+### Test plan
+
+<!--
+  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
+  provide a "test plan". A test plan is a loose explanation of what you have done or
+  implemented to test this, as outlined in our Testing principles and guidelines:
+  https://docs.sourcegraph.com/dev/background-information/testing_principles
+  Write your test plan here after the "Test plan" header.
+-->

--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -1,0 +1,19 @@
+name: pr-auditor
+on:
+  pull_request:
+    types: [ closed, edited, opened ]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with: { repository: 'sourcegraph/sourcegraph' }
+      - uses: actions/setup-go@v2
+        with: { go-version: '1.17' }
+
+      - run: ./dev/pr-auditor/check-pr.sh
+        env:
+          GITHUB_EVENT_PATH: ${{ env.GITHUB_EVENT_PATH }}
+          GITHUB_TOKEN: ${{ secrets.CODENOTIFY_GITHUB_TOKEN }}
+          GITHUB_RUN_URL: https://github.com/sourcegraph/infrastructure/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
This pull request adds test plans to all PR templates, and introduces a pr-auditor workflow to ensure test plans are provided.
For more details see https://github.com/sourcegraph/sourcegraph/issues/30427 and https://docs.sourcegraph.com/dev/background-information/testing_principles

Test plan: created action should correctly set a status on this pull request. No review required: this seems mostly abandoned, the audit tooling is just a formality.

[_Created by Sourcegraph batch change `robert/pr-auditor-rollout`._](https://k8s.sgdev.org/users/robert/batch-changes/pr-auditor-rollout)